### PR TITLE
Close gzip writter when done

### DIFF
--- a/request.go
+++ b/request.go
@@ -63,6 +63,10 @@ func (r Request) send() {
 		if err != nil {
 			log.Fatal(err)
 		}
+		err = gw.Close()
+		if err != nil {
+			log.Fatal(err)
+		}
 		payload = buf.Bytes()
 	} else {
 		payload = r.Payload


### PR DESCRIPTION
https://golang.org/pkg/compress/gzip/#NewWriter

> It is the caller's responsibility to call Close on the Writer when done. Writes may be buffered and not flushed until Close.